### PR TITLE
Update supported rest-assured version to 3.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ will be upgraded to [1.0](http://raml.org/raml-10-spec) soon.
 </plugin>
 ```
 
-- Add dependency to rest-assured (currently tested on `2.8.0`): 
+- Add dependency to rest-assured (currently tested on `3.0.1`): 
 
 ```xml
 <dependency>
-    <groupId>com.jayway.restassured</groupId>
+    <groupId>io.rest-assured</groupId>
     <artifactId>rest-assured</artifactId>
-    <version>2.8.0</version>
+    <version>3.0.1</version>
 </dependency>
 ```
 
@@ -42,15 +42,15 @@ will be upgraded to [1.0](http://raml.org/raml-10-spec) soon.
 
 ```java
 ApiExample.example(
-                ApiExample.Config.exampleConfig()
-                        .withReqSpecSupplier(
-                                () -> new RequestSpecBuilder().setBaseUri("http://your_host/")
-                        )
-        )
-                .rpcApi()
-                .uid().withUid("1")
-                .info()
-                .get(identity()).prettyPeek();
+        ApiExample.Config.exampleConfig()
+                .withReqSpecSupplier(
+                        () -> new RequestSpecBuilder().setBaseUri("http://your_host/")
+                )
+            )
+            .rpcApi()
+            .uid().withUid("1")
+            .info()
+            .get(identity()).prettyPeek();
 ```
 
 See working example in `rarc-example` module.

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -79,9 +80,9 @@
             </dependency>
 
             <dependency>
-                <groupId>com.jayway.restassured</groupId>
+                <groupId>io.rest-assured</groupId>
                 <artifactId>rest-assured</artifactId>
-                <version>2.8.0</version>
+                <version>3.0.1</version>
             </dependency>
 
             <dependency>

--- a/rarc-core/pom.xml
+++ b/rarc-core/pom.xml
@@ -31,7 +31,7 @@
         </dependency>
 
         <dependency>
-            <groupId>com.jayway.restassured</groupId>
+            <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
         </dependency>
 

--- a/rarc-core/src/main/java/ru/lanwen/raml/rarc/api/ra/ActionMethod.java
+++ b/rarc-core/src/main/java/ru/lanwen/raml/rarc/api/ra/ActionMethod.java
@@ -1,12 +1,12 @@
 package ru.lanwen.raml.rarc.api.ra;
 
-import com.jayway.restassured.RestAssured;
-import com.jayway.restassured.response.Response;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeVariableName;
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
 import org.raml.model.Action;
 import ru.lanwen.raml.rarc.api.Method;
 
@@ -52,7 +52,7 @@ public class ActionMethod implements Method {
                 .returns(ClassName.bestGuess("T"))
                 .addJavadoc("$L\n", trimToEmpty(action.getDescription()))
                 .addParameter(handler)
-                .addStatement("return $L.apply($T.given().spec($L.build()).expect().spec($L.build()).$L($L))",
+                .addStatement("return $L.apply($T.given().spec($L.build()).expect().spec($L.build()).when().$L($L))",
                         handler.name,
                         RestAssured.class,
                         reqFieldName,

--- a/rarc-core/src/main/java/ru/lanwen/raml/rarc/api/ra/ReqSpecField.java
+++ b/rarc-core/src/main/java/ru/lanwen/raml/rarc/api/ra/ReqSpecField.java
@@ -1,8 +1,8 @@
 package ru.lanwen.raml.rarc.api.ra;
 
-import com.jayway.restassured.builder.RequestSpecBuilder;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.FieldSpec;
+import io.restassured.builder.RequestSpecBuilder;
 import ru.lanwen.raml.rarc.api.Field;
 
 import javax.lang.model.element.Modifier;

--- a/rarc-core/src/main/java/ru/lanwen/raml/rarc/api/ra/RespSpecField.java
+++ b/rarc-core/src/main/java/ru/lanwen/raml/rarc/api/ra/RespSpecField.java
@@ -1,8 +1,8 @@
 package ru.lanwen.raml.rarc.api.ra;
 
-import com.jayway.restassured.builder.ResponseSpecBuilder;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.FieldSpec;
+import io.restassured.builder.ResponseSpecBuilder;
 import ru.lanwen.raml.rarc.api.Field;
 
 import javax.lang.model.element.Modifier;

--- a/rarc-core/src/main/java/ru/lanwen/raml/rarc/api/ra/root/ReqSpecSupplField.java
+++ b/rarc-core/src/main/java/ru/lanwen/raml/rarc/api/ra/root/ReqSpecSupplField.java
@@ -1,9 +1,9 @@
 package ru.lanwen.raml.rarc.api.ra.root;
 
-import com.jayway.restassured.builder.RequestSpecBuilder;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.FieldSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
+import io.restassured.builder.RequestSpecBuilder;
 import ru.lanwen.raml.rarc.api.Field;
 
 import java.util.function.Supplier;

--- a/rarc-core/src/main/java/ru/lanwen/raml/rarc/rules/BodyRule.java
+++ b/rarc-core/src/main/java/ru/lanwen/raml/rarc/rules/BodyRule.java
@@ -1,7 +1,7 @@
 package ru.lanwen.raml.rarc.rules;
 
-import com.jayway.restassured.path.json.JsonPath;
-import com.jayway.restassured.path.xml.XmlPath;
+import io.restassured.path.json.JsonPath;
+import io.restassured.path.xml.XmlPath;
 import org.raml.model.MimeType;
 
 import java.util.stream.Stream;

--- a/rarc-core/src/main/java/ru/lanwen/raml/rarc/rules/ResourceClassBuilder.java
+++ b/rarc-core/src/main/java/ru/lanwen/raml/rarc/rules/ResourceClassBuilder.java
@@ -1,7 +1,11 @@
 package ru.lanwen.raml.rarc.rules;
 
 import com.squareup.javapoet.JavaFile;
-import org.raml.model.*;
+import org.raml.model.Action;
+import org.raml.model.ActionType;
+import org.raml.model.MimeType;
+import org.raml.model.Resource;
+import org.raml.model.Response;
 import org.raml.model.parameter.AbstractParam;
 import org.raml.model.parameter.FormParameter;
 import org.raml.model.parameter.UriParameter;
@@ -43,7 +47,7 @@ public class ResourceClassBuilder {
     private ArrayList<JavaFile> javaFiles = new ArrayList<>();
 
     ReqSpecField req;
-    RespSpecField resp = new RespSpecField();;
+    RespSpecField resp = new RespSpecField();
 
     public ResourceClassBuilder withCodegenConfig(CodegenConfig codegenConfig) {
         this.codegenConfig = codegenConfig;
@@ -114,7 +118,7 @@ public class ResourceClassBuilder {
     };
 
     Consumer<Response> applyResponseRule = response -> {
-        if(response.hasBody()){
+        if (response.hasBody()) {
             response.getBody().values().forEach(mimeType -> {
                 new ResponseRule().apply(mimeType, this);
             });

--- a/rarc-core/src/main/java/ru/lanwen/raml/rarc/util/JsonCodegen.java
+++ b/rarc-core/src/main/java/ru/lanwen/raml/rarc/util/JsonCodegen.java
@@ -1,7 +1,7 @@
 package ru.lanwen.raml.rarc.util;
 
-import com.jayway.restassured.path.json.JsonPath;
 import com.sun.codemodel.JCodeModel;
+import io.restassured.path.json.JsonPath;
 import org.jsonschema2pojo.DefaultGenerationConfig;
 import org.jsonschema2pojo.GenerationConfig;
 import org.jsonschema2pojo.GsonAnnotator;

--- a/rarc-core/src/main/java/ru/lanwen/raml/rarc/util/ResponseParserClass.java
+++ b/rarc-core/src/main/java/ru/lanwen/raml/rarc/util/ResponseParserClass.java
@@ -1,12 +1,12 @@
 package ru.lanwen.raml.rarc.util;
 
-import com.jayway.restassured.path.json.config.JsonParserType;
-import com.jayway.restassured.path.json.config.JsonPathConfig;
-import com.jayway.restassured.response.Response;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.TypeSpec;
+import io.restassured.path.json.config.JsonParserType;
+import io.restassured.path.json.config.JsonPathConfig;
+import io.restassured.response.Response;
 import org.raml.model.Resource;
 import ru.lanwen.raml.rarc.api.ApiResourceClass;
 import ru.lanwen.raml.rarc.rules.BodyRule;

--- a/rarc-core/src/main/java/ru/lanwen/raml/rarc/util/XmlCodegen.java
+++ b/rarc-core/src/main/java/ru/lanwen/raml/rarc/util/XmlCodegen.java
@@ -1,7 +1,11 @@
 package ru.lanwen.raml.rarc.util;
 
-import com.jayway.restassured.path.xml.XmlPath;
-import org.apache.maven.shared.invoker.*;
+import io.restassured.path.xml.XmlPath;
+import org.apache.maven.shared.invoker.DefaultInvocationRequest;
+import org.apache.maven.shared.invoker.DefaultInvoker;
+import org.apache.maven.shared.invoker.InvocationRequest;
+import org.apache.maven.shared.invoker.InvocationResult;
+import org.apache.maven.shared.invoker.MavenInvocationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/rarc-example/pom.xml
+++ b/rarc-example/pom.xml
@@ -16,7 +16,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.jayway.restassured</groupId>
+            <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
         </dependency>
 

--- a/rarc-example/src/test/java/ru/lanwen/raml/test/ApiExampleUsageTest.java
+++ b/rarc-example/src/test/java/ru/lanwen/raml/test/ApiExampleUsageTest.java
@@ -1,6 +1,6 @@
 package ru.lanwen.raml.test;
 
-import com.jayway.restassured.builder.RequestSpecBuilder;
+import io.restassured.builder.RequestSpecBuilder;
 import org.junit.Ignore;
 import org.junit.Test;
 


### PR DESCRIPTION
These changes provide support for rest-assured features from recent releases. 

If merged, all dependent projects should update their rest-assured version as well.
