### PR TITLE
Use UTF-8 encoding for generated sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ will be upgraded to [1.0](http://raml.org/raml-10-spec) soon.
 </plugin>
 ```
 
-- Add dependency to rest-assured (currently tested on `3.0.1`): 
+- Add dependency to rest-assured (currently tested on `3.0.2`): 
 
 ```xml
 <dependency>
     <groupId>io.rest-assured</groupId>
     <artifactId>rest-assured</artifactId>
-    <version>3.0.1</version>
+    <version>3.0.2</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -81,26 +81,26 @@
             <dependency>
                 <groupId>io.rest-assured</groupId>
                 <artifactId>rest-assured</artifactId>
-                <version>3.0.1</version>
+                <version>3.0.2</version>
             </dependency>
 
             <dependency>
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
-                <version>2.2.4</version>
+                <version>2.8.0</version>
             </dependency>
 
             <!--https://github.com/square/javapoet-->
             <dependency>
                 <groupId>com.squareup</groupId>
                 <artifactId>javapoet</artifactId>
-                <version>1.5.1</version>
+                <version>1.8.0</version>
             </dependency>
 
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.4</version>
+                <version>3.5</version>
             </dependency>
 
             <!--MAVEN DEPS-->
@@ -144,7 +144,7 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-simple</artifactId>
-                <version>1.7.7</version>
+                <version>1.7.24</version>
                 <scope>test</scope>
             </dependency>
 
@@ -158,7 +158,7 @@
             <dependency>
                 <groupId>com.tngtech.java</groupId>
                 <artifactId>junit-dataprovider</artifactId>
-                <version>1.10.0</version>
+                <version>1.12.0</version>
                 <scope>test</scope>
             </dependency>
 


### PR DESCRIPTION
This pull request updates javapoet dependency to 1.8.0. That makes source code generation platform independent, always using UTF-8.