### PR TITLE
Fix duplicate objects

### DIFF
--- a/rarc-core/src/main/java/ru/lanwen/raml/rarc/CodegenConfig.java
+++ b/rarc-core/src/main/java/ru/lanwen/raml/rarc/CodegenConfig.java
@@ -1,7 +1,10 @@
 package ru.lanwen.raml.rarc;
 
+import org.apache.commons.io.FilenameUtils;
+
 import java.nio.file.Path;
-import java.util.List;
+
+import static ru.lanwen.raml.rarc.api.ApiResourceClass.packageName;
 
 /**
  * @author lanwen (Merkushev Kirill)
@@ -34,8 +37,24 @@ public class CodegenConfig {
         return this;
     }
 
+    public static String getObjectPackage(String uri) {
+        return packageName(FilenameUtils.getFullPathNoEndSeparator(uri));
+    }
+
     public String getBasePackage() {
         return basePackage;
+    }
+
+    public String getBaseJsonObjectsPackage() {
+        return getBaseObjectsPackage("jsonObjects");
+    }
+
+    public String getBaseXmlObjectsPackage() {
+        return getBaseObjectsPackage("xmlObjects");
+    }
+
+    private String getBaseObjectsPackage(String type) {
+        return String.format("%s.%s", basePackage, type);
     }
 
     public Path getInputPath() {

--- a/rarc-core/src/main/java/ru/lanwen/raml/rarc/CodegenConfig.java
+++ b/rarc-core/src/main/java/ru/lanwen/raml/rarc/CodegenConfig.java
@@ -1,10 +1,6 @@
 package ru.lanwen.raml.rarc;
 
-import org.apache.commons.io.FilenameUtils;
-
 import java.nio.file.Path;
-
-import static ru.lanwen.raml.rarc.api.ApiResourceClass.packageName;
 
 /**
  * @author lanwen (Merkushev Kirill)
@@ -37,24 +33,12 @@ public class CodegenConfig {
         return this;
     }
 
-    public static String getObjectPackage(String uri) {
-        return packageName(FilenameUtils.getFullPathNoEndSeparator(uri));
-    }
-
     public String getBasePackage() {
         return basePackage;
     }
 
-    public String getBaseJsonObjectsPackage() {
-        return getBaseObjectsPackage("jsonObjects");
-    }
-
-    public String getBaseXmlObjectsPackage() {
-        return getBaseObjectsPackage("xmlObjects");
-    }
-
-    private String getBaseObjectsPackage(String type) {
-        return String.format("%s.%s", basePackage, type);
+    public String getBaseObjectsPackage() {
+        return String.format("%s.%s", basePackage, "objects");
     }
 
     public Path getInputPath() {

--- a/rarc-core/src/main/java/ru/lanwen/raml/rarc/api/ApiResourceClass.java
+++ b/rarc-core/src/main/java/ru/lanwen/raml/rarc/api/ApiResourceClass.java
@@ -5,6 +5,7 @@ import com.google.common.base.Splitter;
 import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.NameAllocator;
 import com.squareup.javapoet.TypeSpec;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.raml.model.Resource;
 
@@ -81,6 +82,14 @@ public class ApiResourceClass {
         enums.forEach(apiClass::addType);
 
         return JavaFile.builder(basePackage + "." + packageName, apiClass.build()).build();
+    }
+
+    public static String addedObjectPackage(String uri) {
+        String path = FilenameUtils.getFullPathNoEndSeparator(uri);
+        if (path.isEmpty()) {
+            return EMPTY;
+        }
+        return "." + packageName(path);
     }
 
     public static String packageName(Resource resource) {

--- a/rarc-core/src/main/java/ru/lanwen/raml/rarc/api/ApiResourceClass.java
+++ b/rarc-core/src/main/java/ru/lanwen/raml/rarc/api/ApiResourceClass.java
@@ -16,8 +16,16 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static java.util.stream.Collectors.*;
-import static org.apache.commons.lang3.StringUtils.*;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
+import static org.apache.commons.lang3.StringUtils.capitalize;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+import static org.apache.commons.lang3.StringUtils.substringAfterLast;
+import static org.apache.commons.lang3.StringUtils.trimToEmpty;
+import static org.apache.commons.lang3.StringUtils.uncapitalize;
+import static org.apache.commons.lang3.StringUtils.upperCase;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
 
 /**
  * @author lanwen (Merkushev Kirill)

--- a/rarc-core/src/main/java/ru/lanwen/raml/rarc/api/ApiResourceClass.java
+++ b/rarc-core/src/main/java/ru/lanwen/raml/rarc/api/ApiResourceClass.java
@@ -15,15 +15,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static java.util.stream.Collectors.groupingBy;
-import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.toList;
-import static org.apache.commons.lang3.StringUtils.capitalize;
-import static org.apache.commons.lang3.StringUtils.isNotEmpty;
-import static org.apache.commons.lang3.StringUtils.substringAfterLast;
-import static org.apache.commons.lang3.StringUtils.trimToEmpty;
-import static org.apache.commons.lang3.StringUtils.uncapitalize;
-import static org.apache.commons.lang3.StringUtils.upperCase;
+import static java.util.stream.Collectors.*;
+import static org.apache.commons.lang3.StringUtils.*;
 
 /**
  * @author lanwen (Merkushev Kirill)
@@ -91,7 +84,11 @@ public class ApiResourceClass {
     }
 
     public static String packageName(Resource resource) {
-        String packageName = sanitize(resource.getUri())
+        return packageName(resource.getUri());
+    }
+
+    public static String packageName(String uri) {
+        String packageName = sanitize(uri)
                 .toLowerCase()
                 .replace("//", "/")
                 .replace("/", ".");

--- a/rarc-core/src/main/java/ru/lanwen/raml/rarc/api/ra/AddJsonBodyMethod.java
+++ b/rarc-core/src/main/java/ru/lanwen/raml/rarc/api/ra/AddJsonBodyMethod.java
@@ -18,7 +18,7 @@ import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 /**
  * Created by stassiak
  */
-public class    AddJsonBodyMethod implements Method {
+public class AddJsonBodyMethod implements Method {
     private String reqName;
     private String returnClassName;
     private Path inputPathForJsonGen;
@@ -56,7 +56,7 @@ public class    AddJsonBodyMethod implements Method {
         return this;
     }
 
-    public AddJsonBodyMethod withShema(Object jsonSchema) {
+    public AddJsonBodyMethod withSchema(Object jsonSchema) {
         this.jsonSchemaPath = jsonSchema.toString();
         return this;
     }
@@ -83,10 +83,12 @@ public class    AddJsonBodyMethod implements Method {
             e.printStackTrace();
         }
 
+        ClassName schemaClassName = ClassName.get(packageForJsonGen, bodyClassName);
+
         return MethodSpec.methodBuilder("with" + bodyClassName)
                 .addJavadoc("$L\n", example)
                 .addModifiers(Modifier.PUBLIC)
-                .addParameter(ClassName.bestGuess(bodyClassName), "body")
+                .addParameter(schemaClassName, "body")
                 .returns(ClassName.bestGuess(returnClassName))
                 .addStatement("$L.addHeader($S, $S)", reqName, "Content-Type", "application/json")
                 .addStatement("$L.setBody(new $T().serializeNulls().create().toJson(body))", reqName, GsonBuilder.class)

--- a/rarc-core/src/main/java/ru/lanwen/raml/rarc/rules/BodyRule.java
+++ b/rarc-core/src/main/java/ru/lanwen/raml/rarc/rules/BodyRule.java
@@ -6,7 +6,7 @@ import org.raml.model.MimeType;
 
 import java.util.stream.Stream;
 
-import static ru.lanwen.raml.rarc.api.ApiResourceClass.packageName;
+import static ru.lanwen.raml.rarc.CodegenConfig.getObjectPackage;
 import static ru.lanwen.raml.rarc.api.ra.AddJsonBodyMethod.bodyMethod;
 import static ru.lanwen.raml.rarc.rules.BodyRule.MimeTypeEnum.byMimeType;
 
@@ -23,13 +23,12 @@ public class BodyRule implements Rule<MimeType> {
             case JSON:
                 resourceClassBuilder.getApiClass().withMethod(
                         bodyMethod()
-                                .withShema(body.getCompiledSchema())
+                                .withSchema(body.getCompiledSchema())
                                 .withExample(body.getExample())
                                 .withReqName(resourceClassBuilder.getReq().name())
                                 .withInputPathForJsonGen(resourceClassBuilder.getCodegenConfig().getInputPath().getParent())
                                 .withOutputPathForJsonGen(resourceClassBuilder.getCodegenConfig().getOutputPath())
-                                .withPackageForJsonGen(resourceClassBuilder.getCodegenConfig().getBasePackage() + "."
-                                        + packageName(resourceClassBuilder.getResource()))
+                                .withPackageForJsonGen(resourceClassBuilder.getCodegenConfig().getBaseJsonObjectsPackage() + "." + getObjectPackage(body.getCompiledSchema().toString()))
                                 .returns(resourceClassBuilder.getApiClass().name()));
                 break;
         }

--- a/rarc-core/src/main/java/ru/lanwen/raml/rarc/rules/BodyRule.java
+++ b/rarc-core/src/main/java/ru/lanwen/raml/rarc/rules/BodyRule.java
@@ -6,7 +6,7 @@ import org.raml.model.MimeType;
 
 import java.util.stream.Stream;
 
-import static ru.lanwen.raml.rarc.CodegenConfig.getObjectPackage;
+import static ru.lanwen.raml.rarc.api.ApiResourceClass.addedObjectPackage;
 import static ru.lanwen.raml.rarc.api.ra.AddJsonBodyMethod.bodyMethod;
 import static ru.lanwen.raml.rarc.rules.BodyRule.MimeTypeEnum.byMimeType;
 
@@ -28,7 +28,8 @@ public class BodyRule implements Rule<MimeType> {
                                 .withReqName(resourceClassBuilder.getReq().name())
                                 .withInputPathForJsonGen(resourceClassBuilder.getCodegenConfig().getInputPath().getParent())
                                 .withOutputPathForJsonGen(resourceClassBuilder.getCodegenConfig().getOutputPath())
-                                .withPackageForJsonGen(resourceClassBuilder.getCodegenConfig().getBaseJsonObjectsPackage() + "." + getObjectPackage(body.getCompiledSchema().toString()))
+                                .withPackageForJsonGen(resourceClassBuilder.getCodegenConfig().getBaseObjectsPackage()
+                                        + addedObjectPackage(body.getCompiledSchema().toString()))
                                 .returns(resourceClassBuilder.getApiClass().name()));
                 break;
         }

--- a/rarc-core/src/main/java/ru/lanwen/raml/rarc/rules/ResourceClassBuilder.java
+++ b/rarc-core/src/main/java/ru/lanwen/raml/rarc/rules/ResourceClassBuilder.java
@@ -46,8 +46,8 @@ public class ResourceClassBuilder {
 
     private ArrayList<JavaFile> javaFiles = new ArrayList<>();
 
-    ReqSpecField req;
-    RespSpecField resp = new RespSpecField();
+    private ReqSpecField req;
+    private RespSpecField resp = new RespSpecField();
 
     public ResourceClassBuilder withCodegenConfig(CodegenConfig codegenConfig) {
         this.codegenConfig = codegenConfig;
@@ -72,7 +72,7 @@ public class ResourceClassBuilder {
             resource.setUriParameters(combined);
         }
 
-        resource.getResources().values().stream().forEach(generateResourseClasses);
+        resource.getResources().values().stream().forEach(generateResourceClasses);
 
         uri = new UriConst(resource.getUri());
         apiClass = ApiResourceClass.forResource(resource)
@@ -82,11 +82,11 @@ public class ResourceClassBuilder {
         responseParser = respParserForResource(resource);
         defaultsMethod = new DefaultsMethod(apiClass, req);
 
-        new ResourseRule().apply(resource, this);
+        new ResourceRule().apply(resource, this);
         javaFiles.stream().forEach(writeTo);
     }
 
-    Consumer<Resource> generateResourseClasses = resource -> {
+    Consumer<Resource> generateResourceClasses = resource -> {
         new ResourceClassBuilder().withCodegenConfig(codegenConfig).withResource(resource).withReq(req).generate();
     };
 

--- a/rarc-core/src/main/java/ru/lanwen/raml/rarc/rules/ResourceRule.java
+++ b/rarc-core/src/main/java/ru/lanwen/raml/rarc/rules/ResourceRule.java
@@ -16,8 +16,8 @@ import static ru.lanwen.raml.rarc.api.ra.NextResourceMethods.childResource;
 /**
  * Created by stassiak
  */
-public class ResourseRule implements Rule<Resource> {
-    private final Logger LOG = LoggerFactory.getLogger(ResourseRule.class);
+public class ResourceRule implements Rule<Resource> {
+    private final Logger LOG = LoggerFactory.getLogger(ResourceRule.class);
 
     @Override
     public void apply(Resource resource, ResourceClassBuilder resourceClassBuilder) {

--- a/rarc-core/src/main/java/ru/lanwen/raml/rarc/rules/ResponseRule.java
+++ b/rarc-core/src/main/java/ru/lanwen/raml/rarc/rules/ResponseRule.java
@@ -11,7 +11,7 @@ import ru.lanwen.raml.rarc.util.XmlCodegen;
 import java.io.File;
 import java.nio.file.Paths;
 
-import static ru.lanwen.raml.rarc.CodegenConfig.getObjectPackage;
+import static ru.lanwen.raml.rarc.api.ApiResourceClass.addedObjectPackage;
 import static ru.lanwen.raml.rarc.rules.BodyRule.MimeTypeEnum.byMimeType;
 
 /**
@@ -36,8 +36,8 @@ public class ResponseRule implements Rule<MimeType> {
                     File xsd = File.createTempFile("schema", "xsd");
                     FileUtils.write(xsd, mimeType.getSchema());
                     respClass = new XmlCodegen(responseCodegenConfig
-                            .withPackageName(resourceClassBuilder.getCodegenConfig().getBaseXmlObjectsPackage() +
-                                    "." + getObjectPackage(xsd.getName()))
+                            .withPackageName(resourceClassBuilder.getCodegenConfig().getBaseObjectsPackage()
+                                    + addedObjectPackage(xsd.getName()))
                             .withSchemaPath(xsd.getName())
                             .withInputPath(Paths.get(xsd.getParent()))).generate();
                     xsd.delete();
@@ -45,9 +45,8 @@ public class ResponseRule implements Rule<MimeType> {
                 case JSON:
                     respClass = new JsonCodegen(
                             responseCodegenConfig
-                                    .withPackageName(resourceClassBuilder.getCodegenConfig()
-                                            .getBaseJsonObjectsPackage() +
-                                            "." + getObjectPackage(mimeType.getCompiledSchema().toString()))
+                                    .withPackageName(resourceClassBuilder.getCodegenConfig().getBaseObjectsPackage()
+                                            + addedObjectPackage(mimeType.getCompiledSchema().toString()))
                                     .withSchemaPath(mimeType.getCompiledSchema().toString())
                                     .withInputPath(resourceClassBuilder.getCodegenConfig().getInputPath().getParent())
                     ).generate();
@@ -58,8 +57,8 @@ public class ResponseRule implements Rule<MimeType> {
 
         if (respClass != null && !resourceClassBuilder.getResponseParser().containsParser(respClass)) {
             resourceClassBuilder.getResponseParser().addParser(respClass, byMimeType(mimeType),
-                    resourceClassBuilder.getCodegenConfig().getBaseJsonObjectsPackage() +
-                            "." + getObjectPackage(mimeType.getCompiledSchema().toString())
+                    resourceClassBuilder.getCodegenConfig().getBaseObjectsPackage()
+                            + addedObjectPackage(mimeType.getCompiledSchema().toString())
             );
         }
     }

--- a/rarc-core/src/main/java/ru/lanwen/raml/rarc/rules/ResponseRule.java
+++ b/rarc-core/src/main/java/ru/lanwen/raml/rarc/rules/ResponseRule.java
@@ -11,7 +11,7 @@ import ru.lanwen.raml.rarc.util.XmlCodegen;
 import java.io.File;
 import java.nio.file.Paths;
 
-import static ru.lanwen.raml.rarc.api.ApiResourceClass.packageName;
+import static ru.lanwen.raml.rarc.CodegenConfig.getObjectPackage;
 import static ru.lanwen.raml.rarc.rules.BodyRule.MimeTypeEnum.byMimeType;
 
 /**
@@ -27,8 +27,6 @@ public class ResponseRule implements Rule<MimeType> {
         }
         LOG.info("Process {}", mimeType.toString());
         ResponseCodegenConfig responseCodegenConfig = ResponseCodegenConfig.config()
-                .withPackageName(resourceClassBuilder.getCodegenConfig().getBasePackage() + "."
-                        + packageName(resourceClassBuilder.getResource()) + ".responses")
                 .withOutputPath(resourceClassBuilder.getCodegenConfig().getOutputPath());
 
         String respClass = null;
@@ -38,6 +36,8 @@ public class ResponseRule implements Rule<MimeType> {
                     File xsd = File.createTempFile("schema", "xsd");
                     FileUtils.write(xsd, mimeType.getSchema());
                     respClass = new XmlCodegen(responseCodegenConfig
+                            .withPackageName(resourceClassBuilder.getCodegenConfig().getBaseXmlObjectsPackage() +
+                                    "." + getObjectPackage(xsd.getName()))
                             .withSchemaPath(xsd.getName())
                             .withInputPath(Paths.get(xsd.getParent()))).generate();
                     xsd.delete();
@@ -45,6 +45,9 @@ public class ResponseRule implements Rule<MimeType> {
                 case JSON:
                     respClass = new JsonCodegen(
                             responseCodegenConfig
+                                    .withPackageName(resourceClassBuilder.getCodegenConfig()
+                                            .getBaseJsonObjectsPackage() +
+                                            "." + getObjectPackage(mimeType.getCompiledSchema().toString()))
                                     .withSchemaPath(mimeType.getCompiledSchema().toString())
                                     .withInputPath(resourceClassBuilder.getCodegenConfig().getInputPath().getParent())
                     ).generate();
@@ -54,8 +57,10 @@ public class ResponseRule implements Rule<MimeType> {
         }
 
         if (respClass != null && !resourceClassBuilder.getResponseParser().containsParser(respClass)) {
-            resourceClassBuilder.getResponseParser().addParser(respClass, byMimeType(mimeType));
+            resourceClassBuilder.getResponseParser().addParser(respClass, byMimeType(mimeType),
+                    resourceClassBuilder.getCodegenConfig().getBaseJsonObjectsPackage() +
+                            "." + getObjectPackage(mimeType.getCompiledSchema().toString())
+            );
         }
-
     }
 }

--- a/rarc-core/src/main/java/ru/lanwen/raml/rarc/rules/RuleFactory.java
+++ b/rarc-core/src/main/java/ru/lanwen/raml/rarc/rules/RuleFactory.java
@@ -24,8 +24,8 @@ public class RuleFactory {
         return codegenConfig;
     }
 
-    public Rule<Resource> getResourseRule() {
-        return new ResourseRule();
+    public Rule<Resource> getResourceRule() {
+        return new ResourceRule();
     }
 
     public Rule<AbstractParam> getParameterRule() {

--- a/rarc-core/src/main/java/ru/lanwen/raml/rarc/util/JsonCodegen.java
+++ b/rarc-core/src/main/java/ru/lanwen/raml/rarc/util/JsonCodegen.java
@@ -2,7 +2,14 @@ package ru.lanwen.raml.rarc.util;
 
 import com.sun.codemodel.JCodeModel;
 import io.restassured.path.json.JsonPath;
-import org.jsonschema2pojo.*;
+
+import org.jsonschema2pojo.DefaultGenerationConfig;
+import org.jsonschema2pojo.GenerationConfig;
+import org.jsonschema2pojo.GsonAnnotator;
+import org.jsonschema2pojo.SchemaGenerator;
+import org.jsonschema2pojo.SchemaMapper;
+import org.jsonschema2pojo.SchemaStore;
+import org.jsonschema2pojo.SourceType;
 import org.jsonschema2pojo.rules.RuleFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/rarc-core/src/main/java/ru/lanwen/raml/rarc/util/ResponseParserClass.java
+++ b/rarc-core/src/main/java/ru/lanwen/raml/rarc/util/ResponseParserClass.java
@@ -39,19 +39,21 @@ public class ResponseParserClass {
         return JavaFile.builder(basePackage + "." + packageName, apiClass.build()).build();
     }
 
-    public ResponseParserClass addParser(String respClass, BodyRule.MimeTypeEnum mimeType) {
-        MethodSpec.Builder methodBilder = MethodSpec.methodBuilder("parse" + respClass)
+    public ResponseParserClass addParser(String respClass, BodyRule.MimeTypeEnum mimeType, String packageForJsonGen) {
+        ClassName className = ClassName.get(packageForJsonGen, respClass);
+
+        MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder("parse" + respClass)
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-                .returns(ClassName.bestGuess(respClass))
+                .returns(className)
                 .addParameter(Response.class, "response");
         Class raPathClass = getRaPathClass(mimeType);
-        if( mimeType.equals(BodyRule.MimeTypeEnum.JSON)) {
-            methodBilder.addStatement("$T.config = new $T().defaultParserType($T.GSON)",
+        if (mimeType.equals(BodyRule.MimeTypeEnum.JSON)) {
+            methodBuilder.addStatement("$T.config = new $T().defaultParserType($T.GSON)",
                     raPathClass, JsonPathConfig.class, JsonParserType.class);
         }
-        methodBilder.addStatement("return $T.from(response.asInputStream()).getObject(\".\", $L.class)",
-                        raPathClass, respClass);
-        parserMethods.put(respClass, methodBilder.build());
+        methodBuilder.addStatement("return $T.from(response.asInputStream()).getObject(\".\", $L.class)",
+                raPathClass, respClass);
+        parserMethods.put(respClass, methodBuilder.build());
         return this;
     }
 

--- a/rarc-core/src/test/java/ru/lanwen/raml/rarc/ApiResourceClassTest.java
+++ b/rarc-core/src/test/java/ru/lanwen/raml/rarc/ApiResourceClassTest.java
@@ -13,7 +13,7 @@ import static org.hamcrest.Matchers.equalTo;
  * @author lanwen (Merkushev Kirill)
  */
 @RunWith(DataProviderRunner.class)
-public class ApiResourseClassTest {
+public class ApiResourceClassTest {
 
     @Test
     @DataProvider({

--- a/rarc-example/src/main/resources/api.raml
+++ b/rarc-example/src/main/resources/api.raml
@@ -107,6 +107,7 @@ traits: !include /traits.yaml
               enumparam_in_form:
                 description: enum parameter in form parameters should not became query parameter and contain underlines
                 enum: [one, 2, underscored_param, for]
+
 /hard_duplicate:
   description: duplicate query and form params
   get:
@@ -139,3 +140,87 @@ traits: !include /traits.yaml
             description: ooops another duplicate param in delete
           form_param_2:
             description: clean form param
+
+/objects_duplicate:
+  description: duplicate response objects
+  get:
+    description: get with duplicate response in post
+    responses:
+      200:
+        description: it's duplicate
+        body:
+          application/json:
+            schema: !include schemas/messageResp.json
+  post:
+    description: post with duplicate body and response
+    body:
+      application/json:
+        schema: !include schemas/messageResp.json
+    responses:
+      200:
+        description: it's duplicate
+        body:
+          application/json:
+            schema: !include schemas/messageResp.json
+
+/subfolder_schema_json:
+  get:
+    responses:
+      200:
+        body:
+          application/json:
+            schema: !include schemas/responses/schema.json
+  post:
+    body:
+      application/json:
+        schema: !include schemas/responses/schema2.json
+    responses:
+      200:
+        body:
+          application/json:
+            schema: !include schemas/responses/schema2.json
+
+
+/ref_schema_json:
+  description: generate with $ref
+  get:
+    description: schema with $ref
+    responses:
+      200:
+        description: $ref
+        body:
+          application/json:
+            schema: !include schemas/schema.json
+  post:
+    description: othershema.json
+    body:
+      application/json:
+        schema: !include schemas/schema.json
+    responses:
+      200:
+        description: it's duplicate
+        body:
+          application/json:
+            schema: !include schemas/otherschema.json
+
+  /child_ref_shchema_json:
+    description: generate with $ref
+    get:
+      description: schema with $ref
+      responses:
+        200:
+          description: $ref
+          body:
+            application/json:
+              schema: !include schemas/schema2.json
+    post:
+      description: othershema.json
+      body:
+        application/json:
+          schema: !include schemas/schema.json
+      responses:
+        200:
+          description: it's duplicate
+          body:
+            application/json:
+              schema: !include schemas/otherschema.json

--- a/rarc-example/src/main/resources/api.raml
+++ b/rarc-example/src/main/resources/api.raml
@@ -108,15 +108,16 @@ traits: !include /traits.yaml
                 description: enum parameter in form parameters should not became query parameter and contain underlines
                 enum: [one, 2, underscored_param, for]
 
-/xsd:
-  post:
-    body:
-      text/xml:
+# NOT WORK YET
+#/xsd:
+#  post:
+#    body:
+#      text/xml:
 #        schema: !include xsd/status.xsd
-    responses:
-      200:
-        body:
-          text/xml:
+#    responses:
+#      200:
+#        body:
+#          text/xml:
 #            schema: !include xsd/status.xsd
 
 /hard_duplicate:
@@ -213,7 +214,17 @@ traits: !include /traits.yaml
         body:
           application/json:
             schema: !include schemas/otherschema.json
-
+# NOT WORK YET
+#  put:
+#    description: schema in resources
+#    body:
+#      application/json:
+#        schema: !include schema.json
+#    responses:
+#      200:
+#        body:
+#          application/json:
+#            schema: !include schema.json
   /child_ref_shchema_json:
     description: generate with $ref
     get:

--- a/rarc-example/src/main/resources/api.raml
+++ b/rarc-example/src/main/resources/api.raml
@@ -108,6 +108,17 @@ traits: !include /traits.yaml
                 description: enum parameter in form parameters should not became query parameter and contain underlines
                 enum: [one, 2, underscored_param, for]
 
+/xsd:
+  post:
+    body:
+      text/xml:
+#        schema: !include xsd/status.xsd
+    responses:
+      200:
+        body:
+          text/xml:
+#            schema: !include xsd/status.xsd
+
 /hard_duplicate:
   description: duplicate query and form params
   get:

--- a/rarc-example/src/main/resources/schema.json
+++ b/rarc-example/src/main/resources/schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://example.com/example.json",
+  "properties": {
+    "id": {
+      "type": "integer"
+    },
+    "name": {
+      "type": "string"
+    }
+  },
+  "type": "object"
+}
+

--- a/rarc-example/src/main/resources/schemas/duplicateResp.json
+++ b/rarc-example/src/main/resources/schemas/duplicateResp.json
@@ -1,0 +1,4 @@
+{
+  "error": "blah",
+  "status" : "blahblah"
+}

--- a/rarc-example/src/main/resources/schemas/otherschema.json
+++ b/rarc-example/src/main/resources/schemas/otherschema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://example.com/example.json",
+  "properties": {
+    "statusId": {
+      "type": "string"
+    },
+    "message": {
+      "type": "string"
+    },
+    "status": {
+      "type": "object",
+      "properties": {
+        "blah": {
+          "type": "string"
+        },
+        "blahblah": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "type": "object"
+}

--- a/rarc-example/src/main/resources/schemas/responses/schema.json
+++ b/rarc-example/src/main/resources/schemas/responses/schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://example.com/example.json",
+  "properties": {
+    "statusId": {
+      "type": "string"
+    },
+    "message": {
+      "type": "string"
+    },
+    "status": {
+      "type": "object",
+      "properties": {
+        "blah": {
+          "type": "string"
+        },
+        "blahblah": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "type": "object"
+}

--- a/rarc-example/src/main/resources/schemas/responses/schema2.json
+++ b/rarc-example/src/main/resources/schemas/responses/schema2.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://example.com/example.json",
+  "properties": {
+    "statusId": {
+      "type": "string"
+    },
+    "message": {
+      "type": "string"
+    },
+    "status": {
+      "type": "object",
+      "properties": {
+        "blah": {
+          "type": "string"
+        },
+        "blahblah": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "type": "object"
+}

--- a/rarc-example/src/main/resources/schemas/schema.json
+++ b/rarc-example/src/main/resources/schemas/schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://example.com/example.json",
+  "properties": {
+    "id": {
+      "type": "integer"
+    },
+    "name": {
+      "type": "string"
+    },
+    "status": {
+      "$ref": "otherschema.json#"
+    }
+  },
+  "type": "object"
+}
+

--- a/rarc-example/src/main/resources/schemas/schema2.json
+++ b/rarc-example/src/main/resources/schemas/schema2.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://example.com/example.json",
+  "properties": {
+    "id": {
+      "type": "integer"
+    },
+    "name": {
+      "type": "string"
+    },
+    "status": {
+      "$ref": "otherschema.json#"
+    }
+  },
+  "type": "object"
+}
+

--- a/rarc-example/src/main/resources/schemas/someResp.json
+++ b/rarc-example/src/main/resources/schemas/someResp.json
@@ -1,0 +1,4 @@
+{
+  "blahblah": "blah",
+  "blah": "blah"
+}

--- a/rarc-example/src/main/resources/xsd/status.xsd
+++ b/rarc-example/src/main/resources/xsd/status.xsd
@@ -1,0 +1,11 @@
+<xs:schema attributeFormDefault="unqualified"
+           elementFormDefault="qualified"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:element name="api-request">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element type="xs:string" name="input"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>


### PR DESCRIPTION
Fix issue of generating duplicated schema classes in case when the same schema path is specified in raml file. 
After fix all schema classes will be generated in one exact folder and will be imported for dependent files.