### PR TITLE
Allow to pass parameter values as objects

### DIFF
--- a/rarc-core/src/main/java/ru/lanwen/raml/rarc/api/ra/AddAnyParamMethod.java
+++ b/rarc-core/src/main/java/ru/lanwen/raml/rarc/api/ra/AddAnyParamMethod.java
@@ -43,7 +43,7 @@ public class AddAnyParamMethod implements AddParamMethod {
                 .addJavadoc("@param $L $L\n", sanitized, trimToEmpty(param.getDescription()))
                 .addModifiers(Modifier.PUBLIC)
                 .returns(ClassName.bestGuess(apiClass.name()))
-                .addParameter(ClassName.get(String.class), sanitized)
+                .addParameter(ClassName.get(Object.class), sanitized)
                 .addStatement("$L.addParam($S, $L)", req.name(), name, sanitized)
                 .addStatement("return this", req.name())
                 .build();

--- a/rarc-core/src/main/java/ru/lanwen/raml/rarc/api/ra/AddFormParamMethod.java
+++ b/rarc-core/src/main/java/ru/lanwen/raml/rarc/api/ra/AddFormParamMethod.java
@@ -45,7 +45,7 @@ public class AddFormParamMethod implements AddParamMethod {
                 .addModifiers(Modifier.PUBLIC)
                 .returns(ClassName.bestGuess(apiClass.name()))
                 .varargs(param.isRepeat())
-                .addParameter(param.isRepeat() ? ArrayTypeName.of(ClassName.get(String.class)) : ClassName.get(String.class), sanitized)
+                .addParameter(param.isRepeat() ? ArrayTypeName.of(ClassName.get(Object.class)) : ClassName.get(Object.class), sanitized)
                 .addStatement("$L.addFormParam($S, $L)", req.name(), name, sanitized)
                 .addStatement("return this", req.name())
                 .build();

--- a/rarc-core/src/main/java/ru/lanwen/raml/rarc/api/ra/AddQueryParamMethod.java
+++ b/rarc-core/src/main/java/ru/lanwen/raml/rarc/api/ra/AddQueryParamMethod.java
@@ -45,7 +45,7 @@ public class AddQueryParamMethod implements AddParamMethod {
                 .addModifiers(Modifier.PUBLIC)
                 .returns(ClassName.bestGuess(apiClass.name()))
                 .varargs(param.isRepeat())
-                .addParameter(param.isRepeat() ? ArrayTypeName.of(ClassName.get(String.class)) : ClassName.get(String.class), sanitized)
+                .addParameter(param.isRepeat() ? ArrayTypeName.of(ClassName.get(Object.class)) : ClassName.get(Object.class), sanitized)
                 .addStatement("$L.addQueryParam($S, $L)", req.name(), name, sanitized)
                 .addStatement("return this", req.name())
                 .build();

--- a/rarc-example/src/main/resources/api.raml
+++ b/rarc-example/src/main/resources/api.raml
@@ -119,7 +119,16 @@ traits: !include /traits.yaml
 #        body:
 #          text/xml:
 #            schema: !include xsd/status.xsd
-
+/passed_as_object_params:
+  description: we can pass param values as object
+  post:
+    queryParameters:
+      object_query_param:
+    body:
+      application/x-www-form-urlencoded:
+        formParameters:
+          object_form_param:
+          null_value_param:
 /hard_duplicate:
   description: duplicate query and form params
   get:

--- a/rarc-example/src/test/java/ru/lanwen/raml/test/ApiExampleUsageTest.java
+++ b/rarc-example/src/test/java/ru/lanwen/raml/test/ApiExampleUsageTest.java
@@ -4,6 +4,8 @@ import io.restassured.builder.RequestSpecBuilder;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.time.Instant;
+
 import static java.util.function.Function.identity;
 
 /**
@@ -13,7 +15,7 @@ import static java.util.function.Function.identity;
 public class ApiExampleUsageTest {
 
     @Test
-    public void shouldBeAbleToCompile() throws Exception {
+    public void shouldBeAbleToCompile() {
         ApiExample.example(
                 ApiExample.Config.exampleConfig()
                         .withReqSpecSupplier(
@@ -35,6 +37,20 @@ public class ApiExampleUsageTest {
                                 () -> new RequestSpecBuilder().setBaseUri("http://your_host/")
                         )
         ).hardDuplicate().withDuplicatedParam("blah").post(identity()).prettyPeek();
+    }
+
+    @Test
+    public void shouldAcceptParamsOfAnyClass() {
+        ApiExample.example(
+                ApiExample.Config.exampleConfig()
+                        .withReqSpecSupplier(
+                                () -> new RequestSpecBuilder().setBaseUri("http://your_host/")
+                        )
+        ).passedAsObjectParams()
+                .withObjectQueryParam(Instant.now())
+                .withObjectFormParam(true)
+                .withNullValueParam(null)
+                .post(identity()).prettyPeek();
     }
 
 }


### PR DESCRIPTION
We get rid of the `String.valueOf()` and things like `"true"` and `"1"`, so code gets clearer. If we override `toString()` for our objects, it's even prettier.

However, the chance to make a mistake increases, as we can pass a non-intended parameter value.